### PR TITLE
(maint) Update redis version, add env REDIS_RECONNECT_ATTEMPTS

### DIFF
--- a/helm-charts/vmpooler/Chart.lock
+++ b/helm-charts/vmpooler/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 10.7.12
-digest: sha256:cd2b6498209e347387f3467403cb063d93a44fdd345cd75fb090eed1eb8debee
-generated: "2020-08-03T16:14:08.491207-07:00"
+  version: 13.0.1
+digest: sha256:7682a105e52b2e1bdd3441f59cc390e0d546655204ae5009295ec3253a25e230
+generated: "2022-03-28T11:00:18.357837-05:00"

--- a/helm-charts/vmpooler/Chart.yaml
+++ b/helm-charts/vmpooler/Chart.yaml
@@ -3,9 +3,9 @@ name: vmpooler
 description: A Helm chart to deploy vmpooler
 type: application
 icon: https://github.com/puppetlabs/vmpooler/raw/master/lib/vmpooler/public/img/logo.png
-version: 1.8.0
+version: 1.9.0
 appVersion: 1.2.0-prod-all-providers
 dependencies:
   - name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 10.7.12
+    version: 13.0.1

--- a/helm-charts/vmpooler/templates/deployment-manager.yaml
+++ b/helm-charts/vmpooler/templates/deployment-manager.yaml
@@ -111,6 +111,8 @@ spec:
           value: "200"
         - name: REDIS_CONNECTION_POOL_TIMEOUT
           value: "40"
+        - name: REDIS_RECONNECT_ATTEMPTS
+          value: "40"
         - name: ONDEMAND_REQUEST_TTL
           value: "50"
         - name: ONDEMAND_CLONE_LIMIT


### PR DESCRIPTION
Update from v10 to v13 of bitnami's redis chart, as it should not contain
breaking changes. Adding REDIS_RECONNECT_ATTEMPTS which defaulted to 10
and is now set to 40, which should result in retrying at least 25 minutes
before returning a failure