### PR TITLE
Migrate issue management to Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # vmpooler-deployment
 
-- [VMPooler Components](#vmpooler-components)
-- [Docker Registry](#docker-registry)
-- [Helm Repository](#helm-repository)
-  - [Adding / updating charts](#adding--updating-charts)
-- [Development](#development)
-  - [Docker Compose URLs](#docker-compose-urls)
-  - [Deploy Chart for Testing](#deploy-chart-for-testing)
-- [Releasing](#releasing)
-- [Contributing](#contributing)
-- [License](#license)
+- [vmpooler-deployment](#vmpooler-deployment)
+  - [VMPooler Components](#vmpooler-components)
+  - [Docker Registry](#docker-registry)
+  - [Helm Repository](#helm-repository)
+    - [Adding / updating charts](#adding--updating-charts)
+  - [Development](#development)
+    - [Docker Compose URLs](#docker-compose-urls)
+    - [Deploy Chart for Testing](#deploy-chart-for-testing)
+  - [Submitting Issues](#submitting-issues)
+  - [Releasing](#releasing)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 This repo contains Dockerfiles and a Helm chart that can be used to deploy [VMPooler](https://github.com/puppetlabs/vmpooler). The Release Engineering team at Puppet uses the code here as part of operating our VMPooler instances.
 
@@ -105,6 +107,10 @@ Helm charts are hosted with GitHub Pages since GitHub Packages does not support 
 
 Artifactory Example:
 `curl -H 'X-JFrog-Art-Api:<YOUR_API_KEY>' -T vmpooler-x.y.z-rc.1.tgz "https://artifactory.example.com/artifactory/helm__local/vmpooler-x.y.z-rc.1.tgz"`
+
+## Submitting Issues
+
+Please file any issues or requests in Jira at <https://puppet.atlassian.net/jira/software/c/projects/POOLER/issues> where project development is tracked across all VMPooler related components.
 
 ## Releasing
 


### PR DESCRIPTION
This is to propose moving issue management to the public Jira project at https://puppet.atlassian.net/jira/software/c/projects/POOLER/issues. If this sounds good, then post merge I'll create a Jira ticket for any open GitHub issues, close the GitHub issue with reference to the Jira ticket, and disable issues on the repository.