### PR TITLE
(maint) Bump vmpooler gem to 3.5.1

### DIFF
--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     tilt (2.2.0)
     trailblazer-option (0.1.2)
     uber (0.1.0)
-    vmpooler (3.5.0)
+    vmpooler (3.5.1)
       concurrent-ruby (~> 1.1)
       connection_pool (~> 2.4)
       deep_merge (~> 1.2)


### PR DESCRIPTION
Relates to https://github.com/puppetlabs/vmpooler/releases/tag/3.5.1