### PR TITLE
(maint) Update vmpooler-provider-vsphere to 3.3.4

### DIFF
--- a/docker/Gemfile.lock
+++ b/docker/Gemfile.lock
@@ -174,7 +174,7 @@ GEM
       google-apis-compute_v1 (~> 0.14)
       googleauth (>= 0.16.2, < 1.4.0)
       vmpooler (~> 3.0)
-    vmpooler-provider-vsphere (3.3.3)
+    vmpooler-provider-vsphere (3.3.4)
       rbvmomi2 (>= 3.1, < 4.0)
       vmpooler (~> 3.0)
     webrick (1.8.1)


### PR DESCRIPTION
Relates to https://github.com/puppetlabs/vmpooler-provider-vsphere/releases/tag/3.3.4