### PR TITLE
(RE-15163) Call BGREWRITEAOF on the redis database every restart to reduce aof file size

### DIFF
--- a/helm-charts/vmpooler/values.yaml
+++ b/helm-charts/vmpooler/values.yaml
@@ -156,6 +156,13 @@ redis:
       initialDelaySeconds: 40
       periodSeconds: 10
       failureThreshold: 10
+    lifecycleHooks:
+      postStart:
+        exec:
+          command:
+          - /bin/sh
+          - -c
+          - echo "AUTH $REDIS_PASSWORD\nBGREWRITEAOF" | redis-cli
   metrics:
     enabled: true
     resources:


### PR DESCRIPTION
The redis docks say that it should be called automatically to reduce the aof file size. However, the bitnami chart (https://github.com/bitnami/charts/issues/8578#issuecomment-1007544927) has a bug that causes it to never do this.