### PR TITLE
(RE-15696) Local Development - Add Grafana and remove redis mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,3 @@
 .vagrant/
 .idea/
 helm-charts/vmpooler/charts/
-/docker/data/redis/**
-!docker/data/**/.gitkeep

--- a/README.md
+++ b/README.md
@@ -87,15 +87,19 @@ When a dependency Helm chart is updated, be sure to run `./update-chart-lock` to
 
 These are the default ports used in the docker compose file, to change them edit the `ports` key under the desired service in either `docker/docker-compose.yml` or `docker/docker-compose.local.yml`.
 
-| App/Endpoint       | Path                                                        |
-|--------------------|-------------------------------------------------------------|
-| Redis Server       | `localhost:6379` (Password: `vmpooler`)                     |
-| Redis Commander    | <http://localhost:8080> (Credentials: `admin:admin`)        |
-| Jaeger             | <http://localhost:8081>
-| VMPooler API       | <http://localhost:8082/api/v3>                              |
-| VMPooler Dashboard | <http://localhost:8082/dashboard>                           |
-| Metrics (API)      | <http://localhost:8082/prometheus>                          |
-| Metrics (Manager)  | <http://localhost:8083/prometheus>                          |
+Tracing data is sent to the Jaeger instance, a prometheus server scrapes metrics, and both are pre-configured in Grafana as datasources for easy visualization and history of data.
+
+| App/Endpoint       | Path                                                         |
+|--------------------|--------------------------------------------------------------|
+| Redis Server       | `localhost:6379` (Password: `vmpooler`)                      |
+| Redis Commander    | <http://localhost:8080> (Credentials: `admin:admin`)         |
+| Jaeger             | <http://localhost:8081>                                      |
+| VMPooler API       | <http://localhost:8082/api/v3>                               |
+| VMPooler Dashboard | <http://localhost:8082/dashboard>                            |
+| Metrics (API)      | <http://localhost:8082/prometheus>                           |
+| Metrics (Manager)  | <http://localhost:8083/prometheus>                           |
+| Prometheus Server  | <http://localhost:9090>                                      |
+| Grafana Server     | <http://localhost:3000> (Credentials: `admin:admin`)         |
 
 ### Deploy Chart for Testing
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -95,3 +95,23 @@ services:
     links:
       - redis-server
       - jaeger-aio
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    links:
+      - vmpooler-api
+      - vmpooler-manager
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    ports:
+     - '3000:3000'
+    links:
+      - prometheus
+      - jaeger-aio

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -5,10 +5,6 @@ services:
     # This should match the major version used in the vmpooler helm chart
     image: redis:6
     command: "redis-server --requirepass vmpooler"
-    volumes:
-      - type: bind
-        source: ./data/redis
-        target: /data
     ports:
       - "6379:6379"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -83,3 +83,23 @@ services:
     links:
       - redis-server
       - jaeger-aio
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    links:
+      - vmpooler-api
+      - vmpooler-manager
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    ports:
+     - '3000:3000'
+    links:
+      - prometheus
+      - jaeger-aio

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,10 +5,6 @@ services:
     # This should match the major version used in the vmpooler helm chart
     image: redis:6
     command: "redis-server --requirepass vmpooler"
-    volumes:
-      - type: bind
-        source: ./data/redis
-        target: /data
     ports:
       - "6379:6379"
 

--- a/docker/grafana/provisioning/datasources/datasource.yml
+++ b/docker/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    url: http://prometheus:9090
+
+  - name: Jaeger
+    type: jaeger
+    url: http://jaeger-aio:16686

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: vmpooler-api
+    metrics_path: /prometheus
+    static_configs:
+      - targets: ['vmpooler-api:4567']
+
+  - job_name: vmpooler-manager
+    metrics_path: /prometheus
+    static_configs:
+      - targets: ['vmpooler-manager:4567']


### PR DESCRIPTION
Remove the unnecessary volume mount in docker compose that saved data outside the container. In fact this can also result in unexpected data because the safe directory was used for both the "developing gems via local source" and "developing gems via git source". Existing users may have to run `docker compose -f docker/docker-compose.dev.yml rm` for the former or `docker compose rm` for the latter to clear a volume bind error.

Also add a pre-configured Prometheus and Grafana container to the docker compose setup so that you can visualize and view historical mertic and tracing data.